### PR TITLE
Add CLI options for bit length and MR iterations

### DIFF
--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -11,6 +11,18 @@ public class Main {
 
     public static void main(String[] args) throws Exception {
         MPI.Init(args);
+
+        // Standardwerte, die ggf. durch CLI-Argumente überschrieben werden
+        int bitLength = 1024;
+        int mrIterations = 20;
+        for (String arg : args) {
+            if (arg.startsWith("-bitlength=")) {
+                bitLength = Integer.parseInt(arg.substring(arg.indexOf('=') + 1));
+            } else if (arg.startsWith("-mriterationen=")) {
+                mrIterations = Integer.parseInt(arg.substring(arg.indexOf('=') + 1));
+            }
+        }
+
         Intracomm comm = MPI.COMM_WORLD;
 
         int rank = comm.Rank();
@@ -28,8 +40,8 @@ public class Main {
         long localStart = globalStart;
 
         do {
-            candidate = new BigInteger(1024, random);
-            boolean isPrime = MillerRabin.isProbablePrimeMR(candidate, 20, random);
+            candidate = new BigInteger(bitLength, random);
+            boolean isPrime = MillerRabin.isProbablePrimeMR(candidate, mrIterations, random);
             sendBuf[0] = isPrime ? 1 : 0;
 
             // informiert alle Prozesse, ob irgendwer eine Primzahl gefunden hat


### PR DESCRIPTION
## Summary
- allow overriding bit length via -bitlength
- allow overriding Miller-Rabin iterations via -mriterationen

## Testing
- `mvn -q test` *(fails: Network is unreachable when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f7f8f4608320aab0fb554aac3185