### PR TITLE
Add MPI-based RSA parallel benchmark

### DIFF
--- a/src/main/java/org/example/RSABenchmark/ParallelRSA.java
+++ b/src/main/java/org/example/RSABenchmark/ParallelRSA.java
@@ -1,0 +1,104 @@
+package org.example.RSABenchmark;
+
+import mpi.Intracomm;
+import mpi.MPI;
+
+import java.math.BigInteger;
+
+/**
+ * RSA helper that parallelises the modular exponentiation of each block
+ * across all MPI ranks.  Rank 0 provides the block data and collects the
+ * results, while every process participates in the exponentiation via
+ * {@link ParallelSchnelleExponentiation}.
+ */
+public final class ParallelRSA {
+
+    private ParallelRSA() {}
+
+    /**
+     * Encrypt blocks with public exponent {@code e} and modulus {@code n}.
+     * The returned array is only valid on rank 0; other ranks return
+     * {@code null} but still participate in the computation.
+     */
+    public static BigInteger[] encrypt(BigInteger[] blocks, BigInteger e, BigInteger n, Intracomm comm) {
+        int rank = comm.Rank();
+        int total = (rank == 0 && blocks != null) ? blocks.length : 0;
+
+        // Broadcast number of blocks and key parameters
+        int[] meta = new int[]{ total };
+        comm.Bcast(meta, 0, 1, MPI.INT, 0);
+        total = meta[0];
+
+        String[] keyMeta = new String[2];
+        if (rank == 0) {
+            keyMeta[0] = e.toString();
+            keyMeta[1] = n.toString();
+        }
+        comm.Bcast(keyMeta, 0, 2, MPI.OBJECT, 0);
+        e = new BigInteger(keyMeta[0]);
+        n = new BigInteger(keyMeta[1]);
+
+        BigInteger[] result = null;
+        if (rank == 0 && total > 0) {
+            result = new BigInteger[total];
+        }
+
+        // Process blocks one after another; each exponentiation is parallel
+        for (int i = 0; i < total; i++) {
+            String[] blockMeta = new String[1];
+            if (rank == 0) {
+                blockMeta[0] = blocks[i].toString();
+            }
+            comm.Bcast(blockMeta, 0, 1, MPI.OBJECT, 0);
+            BigInteger block = new BigInteger(blockMeta[0]);
+
+            BigInteger enc = ParallelSchnelleExponentiation.pow(block, e, n, comm);
+            if (rank == 0) {
+                result[i] = enc;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Decrypt blocks with private exponent {@code d} and modulus {@code n}.
+     * Only rank 0 receives the resulting plaintext blocks.
+     */
+    public static BigInteger[] decrypt(BigInteger[] blocks, BigInteger d, BigInteger n, Intracomm comm) {
+        int rank = comm.Rank();
+        int total = (rank == 0 && blocks != null) ? blocks.length : 0;
+
+        int[] meta = new int[]{ total };
+        comm.Bcast(meta, 0, 1, MPI.INT, 0);
+        total = meta[0];
+
+        String[] keyMeta = new String[2];
+        if (rank == 0) {
+            keyMeta[0] = d.toString();
+            keyMeta[1] = n.toString();
+        }
+        comm.Bcast(keyMeta, 0, 2, MPI.OBJECT, 0);
+        d = new BigInteger(keyMeta[0]);
+        n = new BigInteger(keyMeta[1]);
+
+        BigInteger[] result = null;
+        if (rank == 0 && total > 0) {
+            result = new BigInteger[total];
+        }
+
+        for (int i = 0; i < total; i++) {
+            String[] blockMeta = new String[1];
+            if (rank == 0) {
+                blockMeta[0] = blocks[i].toString();
+            }
+            comm.Bcast(blockMeta, 0, 1, MPI.OBJECT, 0);
+            BigInteger block = new BigInteger(blockMeta[0]);
+
+            BigInteger dec = ParallelSchnelleExponentiation.pow(block, d, n, comm);
+            if (rank == 0) {
+                result[i] = dec;
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/example/RSABenchmark/ParallelRSABenchmark.java
+++ b/src/main/java/org/example/RSABenchmark/ParallelRSABenchmark.java
@@ -1,0 +1,55 @@
+package org.example.RSABenchmark;
+
+import mpi.Intracomm;
+import mpi.MPI;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.example.rsa.RSAUTF8;
+import org.example.rsa.RSAUtils;
+
+/**
+ * Benchmark that runs a single RSA encryption/decryption where the
+ * modular exponentiation is parallelised across MPI processes.
+ * Rank 0 prepares the data and measures the timings.
+ */
+public class ParallelRSABenchmark {
+
+    public static void main(String[] args) throws Exception {
+        MPI.Init(args);
+        Intracomm comm = MPI.COMM_WORLD;
+        int rank = comm.Rank();
+
+        String message = "M\u00f6ge die Macht mit dir sein!";
+        BigInteger e = null, d = null, n = null;
+        BigInteger[] plainBlocks = null;
+
+        if (rank == 0) {
+            RSAUtils.loadKeysFromFiles();
+            e = RSAUtils.getBobPublicKey();
+            d = RSAUtils.getBobPrivateKey();
+            n = RSAUtils.getBobModulus();
+            List<BigInteger> blocks = RSAUTF8.textToBigIntegerBlocks(message, n);
+            plainBlocks = blocks.toArray(new BigInteger[0]);
+            System.out.println("[Benchmark][Rank0] Bl\u00f6cke: " + plainBlocks.length + " | Prozesse: " + comm.Size());
+        }
+
+        long t0 = System.currentTimeMillis();
+        BigInteger[] cipherBlocks = ParallelRSA.encrypt(plainBlocks, e, n, comm);
+        long t1 = System.currentTimeMillis();
+        BigInteger[] decrypted = ParallelRSA.decrypt(cipherBlocks, d, n, comm);
+        long t2 = System.currentTimeMillis();
+
+        if (rank == 0) {
+            int blockSize = RSAUTF8.getEncryptionBlockSize(n);
+            byte[] bytes = RSAUTF8.bigIntegerBlocksToBytes(List.of(decrypted), blockSize);
+            String recovered = new String(bytes, StandardCharsets.UTF_8).trim();
+            System.out.println("[Benchmark][Rank0] Verschl\u00fcsselung: " + (t1 - t0) + " ms");
+            System.out.println("[Benchmark][Rank0] Entschl\u00fcsselung: " + (t2 - t1) + " ms");
+            System.out.println("[Benchmark][Rank0] Zur\u00fcckgewonnener Text: " + recovered);
+        }
+        MPI.Finalize();
+    }
+}

--- a/src/main/java/org/example/RSABenchmark/ParallelSchnelleExponentiation.java
+++ b/src/main/java/org/example/RSABenchmark/ParallelSchnelleExponentiation.java
@@ -1,0 +1,84 @@
+package org.example.RSABenchmark;
+
+import mpi.Intracomm;
+import mpi.MPI;
+
+import java.math.BigInteger;
+
+/**
+ * Parallel variant of the binary modular exponentiation used by RSA.
+ * The exponentiation is decomposed into precomputed powers of the base and
+ * each process multiplies a subset of these powers.  The partial results are
+ * then combined on rank 0 and broadcast back to all ranks.
+ */
+public final class ParallelSchnelleExponentiation {
+
+    private ParallelSchnelleExponentiation() {}
+
+    public static BigInteger pow(BigInteger base, BigInteger exponent, BigInteger modulus, Intracomm comm) {
+        int rank = comm.Rank();
+        int size = comm.Size();
+
+        int bitLen = 0;
+        BigInteger[] powers = null;
+        if (rank == 0) {
+            bitLen = exponent.bitLength();
+            powers = new BigInteger[bitLen];
+            BigInteger cur = base.mod(modulus);
+            for (int i = 0; i < bitLen; i++) {
+                powers[i] = cur;
+                cur = cur.multiply(cur).mod(modulus);
+            }
+        }
+
+        int[] meta = new int[]{ bitLen };
+        comm.Bcast(meta, 0, 1, MPI.INT, 0);
+        bitLen = meta[0];
+
+        // Broadcast powers
+        if (rank != 0) {
+            powers = new BigInteger[bitLen];
+        }
+        if (bitLen > 0) {
+            comm.Bcast(powers, 0, bitLen, MPI.OBJECT, 0);
+        }
+
+        // Broadcast exponent
+        String[] expMeta = new String[1];
+        if (rank == 0) {
+            expMeta[0] = exponent.toString();
+        }
+        comm.Bcast(expMeta, 0, 1, MPI.OBJECT, 0);
+        exponent = new BigInteger(expMeta[0]);
+
+        BigInteger local = BigInteger.ONE;
+        for (int i = rank; i < bitLen; i += size) {
+            if (exponent.testBit(i)) {
+                local = local.multiply(powers[i]).mod(modulus);
+            }
+        }
+
+        BigInteger result;
+        if (rank == 0) {
+            result = local;
+            for (int r = 1; r < size; r++) {
+                BigInteger[] recv = new BigInteger[1];
+                comm.Recv(recv, 0, 1, MPI.OBJECT, r, 0);
+                result = result.multiply(recv[0]).mod(modulus);
+            }
+        } else {
+            comm.Send(new BigInteger[]{ local }, 0, 1, MPI.OBJECT, 0, 0);
+            result = BigInteger.ZERO; // placeholder, will be overwritten
+        }
+
+        // Broadcast final result so every rank returns the same value
+        BigInteger[] resArr;
+        if (rank == 0) {
+            resArr = new BigInteger[]{ result };
+        } else {
+            resArr = new BigInteger[1];
+        }
+        comm.Bcast(resArr, 0, 1, MPI.OBJECT, 0);
+        return resArr[0];
+    }
+}


### PR DESCRIPTION
## Summary
- Parallelize modular exponentiation across MPI ranks via new `ParallelSchnelleExponentiation`
- Rework `ParallelRSA` to iterate blocks sequentially and delegate exponentiation to the parallel routine
- Clarify benchmark description that only the exponentiation is parallelised

## Testing
- `mvn -q -e -DskipTests package` *(fails: PluginResolutionException, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c019e53dd883208663b23a6839f011