### PR TITLE
Distribute RSA block processing across MPI ranks

### DIFF
--- a/src/main/java/org/example/RSABenchmark/ParallelRSA.java
+++ b/src/main/java/org/example/RSABenchmark/ParallelRSA.java
@@ -6,10 +6,10 @@ import mpi.MPI;
 import java.math.BigInteger;
 
 /**
- * RSA helper that parallelises the modular exponentiation of each block
- * across all MPI ranks.  Rank 0 provides the block data and collects the
- * results, while every process participates in the exponentiation via
- * {@link ParallelSchnelleExponentiation}.
+ * RSA helper that distributes block exponentiations across MPI ranks.
+ * Rank 0 broadcasts all block data and collects the results, while each
+ * process performs its assigned exponentiations using
+ * {@link ParallelSchnelleExponentiation} locally.
  */
 public final class ParallelRSA {
 
@@ -22,6 +22,7 @@ public final class ParallelRSA {
      */
     public static BigInteger[] encrypt(BigInteger[] blocks, BigInteger e, BigInteger n, Intracomm comm) {
         int rank = comm.Rank();
+        int size = comm.Size();
         int total = (rank == 0 && blocks != null) ? blocks.length : 0;
 
         // Broadcast number of blocks and key parameters
@@ -38,24 +39,58 @@ public final class ParallelRSA {
         e = new BigInteger(keyMeta[0]);
         n = new BigInteger(keyMeta[1]);
 
+        // Broadcast all blocks once
+        String[] blockMeta = new String[total];
+        if (rank == 0 && blocks != null) {
+            for (int i = 0; i < total; i++) {
+                blockMeta[i] = blocks[i].toString();
+            }
+        }
+        if (total > 0) {
+            comm.Bcast(blockMeta, 0, total, MPI.OBJECT, 0);
+        }
+        BigInteger[] allBlocks = new BigInteger[total];
+        for (int i = 0; i < total; i++) {
+            allBlocks[i] = new BigInteger(blockMeta[i]);
+        }
+
+        // Each rank processes its own block indices
+        int count = 0;
+        for (int i = rank; i < total; i += size) {
+            count++;
+        }
+        int[] indices = new int[count];
+        String[] values = new String[count];
+        int c = 0;
+        for (int i = rank; i < total; i += size) {
+            BigInteger enc = ParallelSchnelleExponentiation.pow(allBlocks[i], e, n, MPI.COMM_SELF);
+            indices[c] = i;
+            values[c] = enc.toString();
+            c++;
+        }
+
         BigInteger[] result = null;
         if (rank == 0 && total > 0) {
             result = new BigInteger[total];
-        }
-
-        // Process blocks one after another; each exponentiation is parallel
-        for (int i = 0; i < total; i++) {
-            String[] blockMeta = new String[1];
-            if (rank == 0) {
-                blockMeta[0] = blocks[i].toString();
+            for (int j = 0; j < count; j++) {
+                result[indices[j]] = new BigInteger(values[j]);
             }
-            comm.Bcast(blockMeta, 0, 1, MPI.OBJECT, 0);
-            BigInteger block = new BigInteger(blockMeta[0]);
-
-            BigInteger enc = ParallelSchnelleExponentiation.pow(block, e, n, comm);
-            if (rank == 0) {
-                result[i] = enc;
+            for (int r = 1; r < size; r++) {
+                int rc = 0;
+                for (int i = r; i < total; i += size) {
+                    rc++;
+                }
+                int[] rIdx = new int[rc];
+                String[] rVal = new String[rc];
+                comm.Recv(rIdx, 0, rc, MPI.INT, r, 0);
+                comm.Recv(rVal, 0, rc, MPI.OBJECT, r, 1);
+                for (int j = 0; j < rc; j++) {
+                    result[rIdx[j]] = new BigInteger(rVal[j]);
+                }
             }
+        } else {
+            comm.Send(indices, 0, count, MPI.INT, 0, 0);
+            comm.Send(values, 0, count, MPI.OBJECT, 0, 1);
         }
         return result;
     }
@@ -66,6 +101,7 @@ public final class ParallelRSA {
      */
     public static BigInteger[] decrypt(BigInteger[] blocks, BigInteger d, BigInteger n, Intracomm comm) {
         int rank = comm.Rank();
+        int size = comm.Size();
         int total = (rank == 0 && blocks != null) ? blocks.length : 0;
 
         int[] meta = new int[]{ total };
@@ -81,23 +117,56 @@ public final class ParallelRSA {
         d = new BigInteger(keyMeta[0]);
         n = new BigInteger(keyMeta[1]);
 
+        String[] blockMeta = new String[total];
+        if (rank == 0 && blocks != null) {
+            for (int i = 0; i < total; i++) {
+                blockMeta[i] = blocks[i].toString();
+            }
+        }
+        if (total > 0) {
+            comm.Bcast(blockMeta, 0, total, MPI.OBJECT, 0);
+        }
+        BigInteger[] allBlocks = new BigInteger[total];
+        for (int i = 0; i < total; i++) {
+            allBlocks[i] = new BigInteger(blockMeta[i]);
+        }
+
+        int count = 0;
+        for (int i = rank; i < total; i += size) {
+            count++;
+        }
+        int[] indices = new int[count];
+        String[] values = new String[count];
+        int c = 0;
+        for (int i = rank; i < total; i += size) {
+            BigInteger dec = ParallelSchnelleExponentiation.pow(allBlocks[i], d, n, MPI.COMM_SELF);
+            indices[c] = i;
+            values[c] = dec.toString();
+            c++;
+        }
+
         BigInteger[] result = null;
         if (rank == 0 && total > 0) {
             result = new BigInteger[total];
-        }
-
-        for (int i = 0; i < total; i++) {
-            String[] blockMeta = new String[1];
-            if (rank == 0) {
-                blockMeta[0] = blocks[i].toString();
+            for (int j = 0; j < count; j++) {
+                result[indices[j]] = new BigInteger(values[j]);
             }
-            comm.Bcast(blockMeta, 0, 1, MPI.OBJECT, 0);
-            BigInteger block = new BigInteger(blockMeta[0]);
-
-            BigInteger dec = ParallelSchnelleExponentiation.pow(block, d, n, comm);
-            if (rank == 0) {
-                result[i] = dec;
+            for (int r = 1; r < size; r++) {
+                int rc = 0;
+                for (int i = r; i < total; i += size) {
+                    rc++;
+                }
+                int[] rIdx = new int[rc];
+                String[] rVal = new String[rc];
+                comm.Recv(rIdx, 0, rc, MPI.INT, r, 0);
+                comm.Recv(rVal, 0, rc, MPI.OBJECT, r, 1);
+                for (int j = 0; j < rc; j++) {
+                    result[rIdx[j]] = new BigInteger(rVal[j]);
+                }
             }
+        } else {
+            comm.Send(indices, 0, count, MPI.INT, 0, 0);
+            comm.Send(values, 0, count, MPI.OBJECT, 0, 1);
         }
         return result;
     }

--- a/src/main/java/org/example/RSABenchmark/ParallelRSABenchmark.java
+++ b/src/main/java/org/example/RSABenchmark/ParallelRSABenchmark.java
@@ -5,6 +5,7 @@ import mpi.MPI;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 
 import org.example.rsa.RSAUTF8;
@@ -39,12 +40,12 @@ public class ParallelRSABenchmark {
         long t0 = System.currentTimeMillis();
         BigInteger[] cipherBlocks = ParallelRSA.encrypt(plainBlocks, e, n, comm);
         long t1 = System.currentTimeMillis();
-        BigInteger[] decrypted = ParallelRSA.decrypt(cipherBlocks, d, n, comm);
+        BigInteger[] decrypted = ParallelRSA.decrypt(rank == 0 ? cipherBlocks : null, d, n, comm);
         long t2 = System.currentTimeMillis();
 
         if (rank == 0) {
             int blockSize = RSAUTF8.getEncryptionBlockSize(n);
-            byte[] bytes = RSAUTF8.bigIntegerBlocksToBytes(List.of(decrypted), blockSize);
+            byte[] bytes = RSAUTF8.bigIntegerBlocksToBytes(Arrays.asList(decrypted), blockSize);
             String recovered = new String(bytes, StandardCharsets.UTF_8).trim();
             System.out.println("[Benchmark][Rank0] Verschl\u00fcsselung: " + (t1 - t0) + " ms");
             System.out.println("[Benchmark][Rank0] Entschl\u00fcsselung: " + (t2 - t1) + " ms");


### PR DESCRIPTION
## Summary
- Broadcast all RSA blocks once and let each MPI rank encrypt/decrypt its own indices before sending results back to rank 0
- Gather index-value pairs on rank 0 to reconstruct the message for both encryption and decryption
- Adjust benchmark to use the new distribution and only print results on rank 0

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c01f6342ec8320858d5e3c5c5b867c