### PR TITLE
Use scatter distribution for parallel RSA and add scaling benchmark

### DIFF
--- a/src/main/java/org/example/RSABenchmark/ParallelRSA.java
+++ b/src/main/java/org/example/RSABenchmark/ParallelRSA.java
@@ -7,7 +7,7 @@ import java.math.BigInteger;
 
 /**
  * RSA helper that distributes block exponentiations across MPI ranks.
- * Rank 0 broadcasts all block data and collects the results, while each
+ * Rank 0 scatters block data to all ranks and gathers the results, while each
  * process performs its assigned exponentiations using
  * {@link ParallelSchnelleExponentiation} locally.
  */
@@ -39,58 +39,48 @@ public final class ParallelRSA {
         e = new BigInteger(keyMeta[0]);
         n = new BigInteger(keyMeta[1]);
 
-        // Broadcast all blocks once
-        String[] blockMeta = new String[total];
+        // Scatter blocks so each rank only receives its portion
+        int base = total / size;
+        int rem = total % size;
+        int[] counts = new int[size];
+        int[] displs = new int[size];
+        int offset = 0;
+        for (int r = 0; r < size; r++) {
+            counts[r] = base + (r < rem ? 1 : 0);
+            displs[r] = offset;
+            offset += counts[r];
+        }
+        int localCount = counts[rank];
+
+        String[] sendBuf = new String[0];
         if (rank == 0 && blocks != null) {
+            sendBuf = new String[total];
             for (int i = 0; i < total; i++) {
-                blockMeta[i] = blocks[i].toString();
+                sendBuf[i] = blocks[i].toString();
             }
         }
+        String[] recvBuf = new String[localCount];
         if (total > 0) {
-            comm.Bcast(blockMeta, 0, total, MPI.OBJECT, 0);
-        }
-        BigInteger[] allBlocks = new BigInteger[total];
-        for (int i = 0; i < total; i++) {
-            allBlocks[i] = new BigInteger(blockMeta[i]);
+            comm.Scatterv(sendBuf, 0, counts, displs, MPI.OBJECT, recvBuf, 0, localCount, MPI.OBJECT, 0);
         }
 
-        // Each rank processes its own block indices
-        int count = 0;
-        for (int i = rank; i < total; i += size) {
-            count++;
-        }
-        int[] indices = new int[count];
-        String[] values = new String[count];
-        int c = 0;
-        for (int i = rank; i < total; i += size) {
-            BigInteger enc = ParallelSchnelleExponentiation.pow(allBlocks[i], e, n, (Intracomm) MPI.COMM_SELF);
-            indices[c] = i;
-            values[c] = enc.toString();
-            c++;
+        // Process received blocks locally
+        String[] localVals = new String[localCount];
+        for (int i = 0; i < localCount; i++) {
+            BigInteger enc = ParallelSchnelleExponentiation.pow(new BigInteger(recvBuf[i]), e, n, (Intracomm) MPI.COMM_SELF);
+            localVals[i] = enc.toString();
         }
 
         BigInteger[] result = null;
         if (rank == 0 && total > 0) {
+            String[] gathered = new String[total];
+            comm.Gatherv(localVals, 0, localCount, MPI.OBJECT, gathered, 0, counts, displs, MPI.OBJECT, 0);
             result = new BigInteger[total];
-            for (int j = 0; j < count; j++) {
-                result[indices[j]] = new BigInteger(values[j]);
+            for (int i = 0; i < total; i++) {
+                result[i] = new BigInteger(gathered[i]);
             }
-            for (int r = 1; r < size; r++) {
-                int rc = 0;
-                for (int i = r; i < total; i += size) {
-                    rc++;
-                }
-                int[] rIdx = new int[rc];
-                String[] rVal = new String[rc];
-                comm.Recv(rIdx, 0, rc, MPI.INT, r, 0);
-                comm.Recv(rVal, 0, rc, MPI.OBJECT, r, 1);
-                for (int j = 0; j < rc; j++) {
-                    result[rIdx[j]] = new BigInteger(rVal[j]);
-                }
-            }
-        } else {
-            comm.Send(indices, 0, count, MPI.INT, 0, 0);
-            comm.Send(values, 0, count, MPI.OBJECT, 0, 1);
+        } else if (total > 0) {
+            comm.Gatherv(localVals, 0, localCount, MPI.OBJECT, new String[0], 0, counts, displs, MPI.OBJECT, 0);
         }
         return result;
     }
@@ -117,56 +107,48 @@ public final class ParallelRSA {
         d = new BigInteger(keyMeta[0]);
         n = new BigInteger(keyMeta[1]);
 
-        String[] blockMeta = new String[total];
+        // Scatter blocks so each rank only receives its portion
+        int base = total / size;
+        int rem = total % size;
+        int[] counts = new int[size];
+        int[] displs = new int[size];
+        int offset = 0;
+        for (int r = 0; r < size; r++) {
+            counts[r] = base + (r < rem ? 1 : 0);
+            displs[r] = offset;
+            offset += counts[r];
+        }
+        int localCount = counts[rank];
+
+        String[] sendBuf = new String[0];
         if (rank == 0 && blocks != null) {
+            sendBuf = new String[total];
             for (int i = 0; i < total; i++) {
-                blockMeta[i] = blocks[i].toString();
+                sendBuf[i] = blocks[i].toString();
             }
         }
+        String[] recvBuf = new String[localCount];
         if (total > 0) {
-            comm.Bcast(blockMeta, 0, total, MPI.OBJECT, 0);
-        }
-        BigInteger[] allBlocks = new BigInteger[total];
-        for (int i = 0; i < total; i++) {
-            allBlocks[i] = new BigInteger(blockMeta[i]);
+            comm.Scatterv(sendBuf, 0, counts, displs, MPI.OBJECT, recvBuf, 0, localCount, MPI.OBJECT, 0);
         }
 
-        int count = 0;
-        for (int i = rank; i < total; i += size) {
-            count++;
-        }
-        int[] indices = new int[count];
-        String[] values = new String[count];
-        int c = 0;
-        for (int i = rank; i < total; i += size) {
-            BigInteger dec = ParallelSchnelleExponentiation.pow(allBlocks[i], d, n, (Intracomm) MPI.COMM_SELF);
-            indices[c] = i;
-            values[c] = dec.toString();
-            c++;
+        // Process received blocks locally
+        String[] localVals = new String[localCount];
+        for (int i = 0; i < localCount; i++) {
+            BigInteger dec = ParallelSchnelleExponentiation.pow(new BigInteger(recvBuf[i]), d, n, (Intracomm) MPI.COMM_SELF);
+            localVals[i] = dec.toString();
         }
 
         BigInteger[] result = null;
         if (rank == 0 && total > 0) {
+            String[] gathered = new String[total];
+            comm.Gatherv(localVals, 0, localCount, MPI.OBJECT, gathered, 0, counts, displs, MPI.OBJECT, 0);
             result = new BigInteger[total];
-            for (int j = 0; j < count; j++) {
-                result[indices[j]] = new BigInteger(values[j]);
+            for (int i = 0; i < total; i++) {
+                result[i] = new BigInteger(gathered[i]);
             }
-            for (int r = 1; r < size; r++) {
-                int rc = 0;
-                for (int i = r; i < total; i += size) {
-                    rc++;
-                }
-                int[] rIdx = new int[rc];
-                String[] rVal = new String[rc];
-                comm.Recv(rIdx, 0, rc, MPI.INT, r, 0);
-                comm.Recv(rVal, 0, rc, MPI.OBJECT, r, 1);
-                for (int j = 0; j < rc; j++) {
-                    result[rIdx[j]] = new BigInteger(rVal[j]);
-                }
-            }
-        } else {
-            comm.Send(indices, 0, count, MPI.INT, 0, 0);
-            comm.Send(values, 0, count, MPI.OBJECT, 0, 1);
+        } else if (total > 0) {
+            comm.Gatherv(localVals, 0, localCount, MPI.OBJECT, new String[0], 0, counts, displs, MPI.OBJECT, 0);
         }
         return result;
     }

--- a/src/main/java/org/example/RSABenchmark/ParallelRSAScalingBenchmark.java
+++ b/src/main/java/org/example/RSABenchmark/ParallelRSAScalingBenchmark.java
@@ -1,0 +1,97 @@
+package org.example.RSABenchmark;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Runs {@link ParallelRSABenchmark} for different process counts and
+ * prints a table with total runtime and speedup based on encryption
+ * plus decryption times.
+ */
+public class ParallelRSAScalingBenchmark {
+
+    private static final Pattern ENC_PATTERN =
+            Pattern.compile("Versch.*?:\\s*([0-9.,]+) ms");
+    private static final Pattern DEC_PATTERN =
+            Pattern.compile("Entsch.*?:\\s*([0-9.,]+) ms");
+
+    private record Result(int np, double totalMs) {}
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        int maxProcs = Runtime.getRuntime().availableProcessors();
+        List<Integer> npValues = new ArrayList<>();
+        for (int np = 1; np <= maxProcs; np *= 2) {
+            npValues.add(np);
+        }
+
+        List<Result> results = new ArrayList<>();
+        Path logDir = Paths.get("logs");
+        Files.createDirectories(logDir);
+
+        String mpjRun = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win")
+                ? "mpjrun.bat" : "mpjrun.sh";
+
+        for (int np : npValues) {
+            ProcessBuilder pb = new ProcessBuilder(
+                    mpjRun, "-np", String.valueOf(np),
+                    "-cp", "target/classes",
+                    ParallelRSABenchmark.class.getName());
+            pb.redirectErrorStream(true);
+            Process proc = pb.start();
+
+            StringBuilder out = new StringBuilder();
+            try (BufferedReader br = new BufferedReader(
+                    new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    out.append(line).append(System.lineSeparator());
+                }
+            }
+            proc.waitFor();
+
+            String content = out.toString();
+            Files.writeString(logDir.resolve("ParallelRSAScalingBenchmark_np" + np + ".log"),
+                    content, StandardCharsets.UTF_8);
+
+            Matcher em = ENC_PATTERN.matcher(content);
+            Matcher dm = DEC_PATTERN.matcher(content);
+            if (em.find() && dm.find()) {
+                double enc = parseDouble(em.group(1));
+                double dec = parseDouble(dm.group(1));
+                results.add(new Result(np, enc + dec));
+            }
+        }
+
+        if (results.isEmpty()) return;
+
+        double baseline = results.get(0).totalMs;
+        StringBuilder table = new StringBuilder();
+        table.append(String.format(Locale.ROOT, "%4s %12s %10s%n", "np", "total ms", "speedup"));
+        for (Result r : results) {
+            double speed = baseline / r.totalMs;
+            table.append(String.format(Locale.ROOT, "%4d %12.3f %10.3f%n", r.np, r.totalMs, speed));
+        }
+
+        System.out.print(table);
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
+        Files.writeString(logDir.resolve("ParallelRSAScalingBenchmark_" + fmt.format(LocalDateTime.now()) + ".log"),
+                table.toString(), StandardCharsets.UTF_8);
+    }
+
+    private static double parseDouble(String s) {
+        return Double.parseDouble(s.replace(',', '.'));
+    }
+}
+


### PR DESCRIPTION
## Summary
- Replace block broadcast with scatter so each MPI rank receives only its portion.
- Gather encrypted/decrypted block results with Gatherv and correct MPI argument order.
- Introduce `ParallelRSAScalingBenchmark` to run the benchmark across multiple process counts and report speedup.

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0266e6914832091e36aef602cb28e